### PR TITLE
eks-cluster-setup: Use Ubuntu20.04 instances

### DIFF
--- a/eks-cluster-setup/cluster.yaml
+++ b/eks-cluster-setup/cluster.yaml
@@ -16,7 +16,7 @@ kind: ClusterConfig
 kubernetesNetworkConfig:
   ipFamily: IPv4
 managedNodeGroups:
-- amiFamily: AmazonLinux2
+- amiFamily: Ubuntu2004
   iam:
     withAddonPolicies:
       ebs: true


### PR DESCRIPTION
Modify cluster.yaml file for EKS cluster to spin up Ubuntu20.04 instances instead AmazonLinux2 ones. Before merging this, we should test that MLFlow works too with this change.