### PR TITLE
DOCS: add markdown cells to build-your-first-ml-model notebook

### DIFF
--- a/build-your-first-ml-model/build-your-first-ml-model.ipynb
+++ b/build-your-first-ml-model/build-your-first-ml-model.ipynb
@@ -1,6 +1,49 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "c845ad4f",
+   "metadata": {},
+   "source": [
+    "# Build your First ML Model\n",
+    "\n",
+    "This notebook walks through an end-to-end example of how to download, \n",
+    "preprocess, train, deploy, and serve a machine learning model using \n",
+    "Kubeflow Pipelines, MLflow and KServe.\n",
+    "\n",
+    "The dataset used is the Wine Quality dataset, and the model predicts \n",
+    "wine quality using a linear regression approach.\n",
+    "\n",
+    "## Table of Contents\n",
+    "1. [Install Dependencies](#Install-Dependencies)\n",
+    "2. [Import Libraries](#Import-libraries)\n",
+    "3. [Kubeflow Pipeline Components](#Kubeflow-Pipeline-Components)\n",
+    "    - [Data Gathering Component](#data-gathering-component)\n",
+    "    - [Preprocessing Component](#preprocessing-component)\n",
+    "    - [Training Component](#training-component)\n",
+    "    - [Deploy Component](#deploy-component)\n",
+    "4. [Kubeflow Pipeline Outline](#Kubeflow-Pipeline-Outline)\n",
+    "5. [Run the Pipeline](#Run-the-Pipeline)\n",
+    "6. [Wait for the Pipeline to Complete](#Wait-for-the-Pipeline-Run-to-Complete)\n",
+    "7. [Test the Deployed Model](#Test-the-Deployed-Model)\n",
+    "8. [Cluster Cleanup](#Cluster-Cleanup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1c0a817",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies\n",
+    "\n",
+    "The following libraries are required to run this notebook:\n",
+    "- **kfp**: define and run Kubeflow Pipelines components\n",
+    "- **mlflow**: track experiments and register the trained model\n",
+    "- **kserve**: deploy the model as a REST inference service\n",
+    "- **tenacity**: handle retries for async operations"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "3451706c-7adb-48af-9c26-3967a808374e",
@@ -10,6 +53,16 @@
    "outputs": [],
    "source": [
     "!pip install kfp==2.5.0 mlflow==2.15.1 kserve==0.13.1 tenacity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a01fe487",
+   "metadata": {},
+   "source": [
+    "## Import libraries \n",
+    "\n",
+    "Import the necessary libraries that will be used throughout the notebook."
    ]
   },
   {
@@ -32,8 +85,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1a6b18a3",
+   "metadata": {},
+   "source": [
+    "## Kubeflow Pipeline Components\n",
+    "\n",
+    "Components are the basic building blocks of a Kubeflow Pipeline. They contain all the necessary elements for that specific container. The base image the container will use, dependencies that need to be installed and the code they will execute. \n",
+    "\n",
+    "This allows the minimum required dependencies for the container to run effectively.\n",
+    "\n",
+    "The `@component` decorator is used to define these building blocks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f90dea0a",
+   "metadata": {},
+   "source": [
+    "### Data Gathering Component\n",
+    "\n",
+    "\n",
+    "This container will be in charge of downloading the dataset used for training. \n",
+    "\n",
+    "Note that `requests` and `pandas` are imported directly inside the component. Those are the only dependencies needed for the dataset loading container.\n",
+    "\n",
+    "Note that only an `OutputPath` parameter is defined, since the component is in charge of downloading the data with a URL, no need for an `InputPath`."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8c23f1b1-d42c-47f5-a4c4-956df3f53d4a",
    "metadata": {},
    "outputs": [],
@@ -56,6 +138,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "77a61dc1",
+   "metadata": {},
+   "source": [
+    "### Preprocessing Component\n",
+    "\n",
+    "Now, we define the `preprocess_dataset` component. \n",
+    "\n",
+    "In this case, we have both `InputPath` and `OutputPath` defined:\n",
+    "\n",
+    "`dataset: InputPath('Dataset')`: We are taking the dataset from previous component as the input for this preprocess step.\n",
+    "`output_file: OutputPath('Dataset')`: Once the dataset is preprocessed, we are going to output it in a standardized format ready for training.\n",
+    "\n",
+    "**Note**: Parquet is a columnar file format optimized for data storage, with smaller sizes compared to CSV."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "e4e7351f-054b-46b7-bd13-08587f685c6f",
@@ -72,6 +171,25 @@
     "    df = pd.read_csv(dataset, header=0)\n",
     "    df.columns = [c.lower().replace(\" \", \"_\") for c in df.columns]\n",
     "    df.to_parquet(output_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "769b4c8b",
+   "metadata": {},
+   "source": [
+    "### Training Component\n",
+    "\n",
+    "We define the component in charge of training the model with our preprocessed dataset.\n",
+    "\n",
+    "#### Steps\n",
+    "\n",
+    "1. We read our Parquet file imported as our `InputPath` file.\n",
+    "2. We define the target variable to train on, `quality` in this case.\n",
+    "3. Split the data into train and test with `train_test_split`: we leave 25% of the data for testing purposes.\n",
+    "4. `mlflow.sklearn.autolog()` will log metrics, parameters and the model automatically when running `mlflow.start_run()`.\n",
+    "5. The linear regressor is created and then trained on the training set. The Machine Learning algorithm is `ElasticNet`, a linear regression model with L1 and L2 regularization.\n",
+    "6. `model_uri` will be a parameter of the Deploy Component, so it uses the correct model.\n"
    ]
   },
   {
@@ -113,6 +231,25 @@
     "        model_uri = f\"{run.info.artifact_uri}/model\"\n",
     "        print(model_uri)\n",
     "        return model_uri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f82a61c",
+   "metadata": {},
+   "source": [
+    "### Deploy Component\n",
+    "\n",
+    "This component takes the `model_uri` returned by the Training Component and deploys it as a REST inference service using KServe.\n",
+    "\n",
+    "#### Steps\n",
+    "\n",
+    "1. An `InferenceService` object is defined, specifying the model type (`sklearn`), the location of the model (`model_uri`), and the service account with access to S3 where the model is stored.\n",
+    "2. The `InferenceService` is created in the cluster via the KServe client.\n",
+    "3. `tenacity` is used to retry (`@retry` decorator) the readiness check until the service is up, waiting up to 30 attempts before failing. This is due to the async nature of the deploy.\n",
+    "4. Once ready, the inference URL is retrieved and returned. this is the endpoint that will be used to send prediction requests.\n",
+    "\n",
+    "**Note**: When creating the Inference Service, Istio sidecar injection is disabled for this service to simplify networking in the cluster (`annotations={\"sidecar.istio.io/inject\": \"false\"}`)."
    ]
   },
   {
@@ -175,6 +312,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "02644217",
+   "metadata": {},
+   "source": [
+    "# Kubeflow Pipeline Outline\n",
+    "\n",
+    "Now that we have defined all the Components, we can assemble them into a \n",
+    "Kubeflow Pipeline using the `@pipeline` decorator.\n",
+    "\n",
+    "The pipeline connects four steps in sequence: data gathering, preprocessing, \n",
+    "training, and deployment. The output of each step is passed as the input to \n",
+    "the next."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "738b2cf4",
+   "metadata": {},
+   "source": [
+    "## Configuration and Pipeline Definition\n",
+    "\n",
+    "Before defining the pipeline, we set the names for the MLflow run, the \n",
+    "registered model, and the KServe inference service.\n",
+    "\n",
+    "Credentials for MLflow and S3 are read from environment variables rather \n",
+    "than hardcoded, which is a security best practice. These need to be set \n",
+    "in your Kubeflow Notebook environment before running this cell."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "4faf3aa7-6145-4734-afad-a18fb301a657",
@@ -208,6 +375,27 @@
     "    deploy_task = deploy_model_with_kserve(\n",
     "        model_uri=train_task.output, isvc_name=ISVC_NAME\n",
     "    ).set_env_variable(name='AWS_SECRET_ACCESS_KEY', value=aws_secret_access_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c37dbfd8",
+   "metadata": {},
+   "source": [
+    "## Run the Pipeline\n",
+    "\n",
+    "We connect to the Kubeflow Pipelines API using `kfp.Client()`. It allows \n",
+    "us to interact with the cluster programmatically.\n",
+    "\n",
+    "The pipeline is first compiled into a YAML file. This is the static \n",
+    "representation of the pipeline that Kubeflow understands. It can also be \n",
+    "uploaded manually via the Kubeflow UI.\n",
+    "\n",
+    "Finally, the pipeline is submitted as a run, passing the dataset URL as \n",
+    "the argument. \n",
+    "\n",
+    "**Note**: Caching is disabled so that all steps are executed on every \n",
+    "run, regardless of whether the inputs have changed."
    ]
   },
   {
@@ -260,6 +448,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0617f293",
+   "metadata": {},
+   "source": [
+    "## Wait for the Pipeline Run to Complete\n",
+    "\n",
+    "Since the pipeline runs asynchronously in the cluster, this cell polls \n",
+    "the run status until it reaches a `SUCCEEDED` state.\n",
+    "\n",
+    "It retries up to 90 times using an exponential backoff strategy, starting \n",
+    "with short waits and progressively increasing up to 10 seconds between \n",
+    "attempts before raising an error if the run didn't succeed."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "d920ae31-3991-43b7-a5ae-57691cb08a6b",
@@ -277,6 +480,18 @@
     "    assert state == \"SUCCEEDED\", f\"KFP run is in {state} state.\"\n",
     "\n",
     "assert_kfp_run_succeeded(client, run.run_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04abeb52",
+   "metadata": {},
+   "source": [
+    "## Test the Deployed Model\n",
+    "\n",
+    "Once the pipeline has succeeded, we retrieve the inference service URL and send a prediction request to validate that the model is working correctly.\n",
+    "\n",
+    "The input consists of two wine samples, each described by 11 feature values. The model returns a predicted quality score for each sample."
    ]
   },
   {
@@ -312,6 +527,32 @@
     "\n",
     "response = requests.post(f\"{inference_service_url}/v1/models/{ISVC_NAME}:predict\", json=input_data)\n",
     "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19a70e7d",
+   "metadata": {},
+   "source": [
+    "## Prediction Output Validation\n",
+    "\n",
+    "We see from the above cell's output that the model retrieved two predictions, one for each list of features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e34e21ec",
+   "metadata": {},
+   "source": [
+    "## Cluster Cleanup\n",
+    "\n",
+    "To avoid leaving unused resources running in the cluster, we delete both \n",
+    "the KServe inference service and the registered model in MLflow.\n",
+    "\n",
+    "The deletion of the inference service is also asynchronous, so `tenacity` \n",
+    "is used again to confirm it has been fully removed before proceeding. The \n",
+    "check passes either when the service no longer exists or when a \"Not Found\" \n",
+    "error is returned by the cluster.\n"
    ]
   },
   {

--- a/build-your-first-ml-model/build-your-first-ml-model.ipynb
+++ b/build-your-first-ml-model/build-your-first-ml-model.ipynb
@@ -95,7 +95,9 @@
     "\n",
     "This allows the minimum required dependencies for the container to run effectively.\n",
     "\n",
-    "The `@component` decorator is used to define these building blocks."
+    "The `@component` decorator is used to define these building blocks.\n",
+    "\n",
+    "You can read more about Kubeflow Pipelines in the [official documentation](https://www.kubeflow.org/docs/components/pipelines/overview/)"
    ]
   },
   {
@@ -187,8 +189,8 @@
     "1. We read our Parquet file imported as our `InputPath` file.\n",
     "2. We define the target variable to train on, `quality` in this case.\n",
     "3. Split the data into train and test with `train_test_split`: we leave 25% of the data for testing purposes.\n",
-    "4. `mlflow.sklearn.autolog()` will log metrics, parameters and the model automatically when running `mlflow.start_run()`.\n",
-    "5. The linear regressor is created and then trained on the training set. The Machine Learning algorithm is `ElasticNet`, a linear regression model with L1 and L2 regularization.\n",
+    "4. `mlflow.sklearn.autolog()` will log metrics, parameters and the model automatically when running `mlflow.start_run()`. You can learn more about `mlflow.autolog()` in the [official documentation](https://mlflow.org/docs/latest/ml/tracking/autolog)\n",
+    "5. The linear regressor is created and then trained on the training set. The Machine Learning algorithm is `ElasticNet`, a linear regression model with L1 and L2 regularization. Learn more about it in the [official documentation](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html)\n",
     "6. `model_uri` will be a parameter of the Deploy Component, so it uses the correct model.\n"
    ]
   },
@@ -527,16 +529,6 @@
     "\n",
     "response = requests.post(f\"{inference_service_url}/v1/models/{ISVC_NAME}:predict\", json=input_data)\n",
     "print(response.text)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19a70e7d",
-   "metadata": {},
-   "source": [
-    "## Prediction Output Validation\n",
-    "\n",
-    "We see from the above cell's output that the model retrieved two predictions, one for each list of features."
    ]
   },
   {


### PR DESCRIPTION
Closes #48

## Changes
- Add introductory Markdown cell with Table of Contents
- Add Markdown cells before each code block explaining what it does, 
  what it produces, and how it fits into the pipeline
- Add links to official documentation for Kubeflow Pipelines, MLflow autolog 
  and ElasticNet model